### PR TITLE
DEVOPS-1750: Update Circleci orb version in use to travelaudience/go@0.9.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ta-go: travelaudience/go@0.8.0
+  ta-go: travelaudience/go@0.9.3
 
 executors:
   golang-executor:


### PR DESCRIPTION
Updating the orb version used to travelaudience/go@0.9.3 as part of Codeclimate deprecation