### PR TITLE
Remove random seed; update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,12 @@
 version: 2.1
 
 orbs:
-  ta-go: travelaudience/go@0.9.3
+  ta-go: travelaudience/go@0.9
 
 executors:
   golang-executor:
     docker:
-    - image: golang:1.19.0-bullseye
-    environment:
-      GO111MODULE: "on"
-      GOPRIVATE: github.com/travelaudience/*
-    working_directory: /go/src/github.com/travelaudience/go-sx/
+    - image: cimg/go:1.23
 
 workflows:
   build_and_test:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/travelaudience/go-sx
 
-go 1.19
+go 1.23
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.3.3
-	github.com/mattn/go-sqlite3 v1.11.0
+	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/mattn/go-sqlite3 v1.14.24
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
-github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
-github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
-github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/tx_test.go
+++ b/tx_test.go
@@ -4,36 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"flag"
-	"fmt"
 	"math/rand"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 
 	sx "github.com/travelaudience/go-sx"
 )
 
-var randseed int64
-
-func init() {
-	// The tests here use pseudo-random numbers for parameters whose values shouldn't matter.  The random number
-	// generator is seeded with the lower 16 bits of unix nanotime by default.  If for some odd reason there is a
-	// particular pseudo-random sequence that fails, we can reproduce the sequence by explicitly setting the seed.
-	flag.Int64Var(&randseed, "seed", 0, "seed the random number generator")
-}
-
 func TestMain(m *testing.M) {
-	flag.Parse()
-	if randseed == 0 {
-		randseed = time.Now().UnixNano() % 65536
-	}
-	rand.Seed(randseed)
-	// Display the seed so that we can reproduce the test run if needed.
-	fmt.Printf("Using seed %d.\n", randseed)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Minor maintenance update.

- Updates Go version to 1.23.
- Updates versions of dependencies.
- Simplifies the CI configuration.
- Removes the explicit random seed from the tests.
